### PR TITLE
Develop devise omniauth

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -231,7 +231,7 @@
 /* devise-omniauth */
 .omniauth-facebook {
     width: 70%;
-    margin: 40px auto;
+    margin: 40px auto 20px;
     padding: 10px 25px;
     background-color: rgba(14, 87, 246, 0.861);
     border-radius: 5px;

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -71,6 +71,7 @@
 
     <!-- omniauth -->
     <%= render "users/shared/links" %>
+    <p><small>アカウント名は15文字以下となります。</small></p>
 
     <hr>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -48,6 +48,7 @@
 
     <!-- omniauth -->
     <%= render "users/shared/links" %>
+    <p><small>アカウント名は15文字以下となります。</small></p>
 
     <hr>
 


### PR DESCRIPTION
omniauth認証の仕組みを大まかに理解（自分が）
１，facebookのアカウント名が15文字以上のユーザのomniauth認証時のバリデーションエラーの修正
２，new_with_sessionメソッドの追加